### PR TITLE
Fix non digit NI validator

### DIFF
--- a/bot/application/student/validators/ni_validator.py
+++ b/bot/application/student/validators/ni_validator.py
@@ -6,4 +6,4 @@ class NIValidator:
         pass
 
     def validate(self, ni: str) -> bool:
-        return len(ni) is self.NI_DIGITS_COUNT
+        return len(ni) == self.NI_DIGITS_COUNT and ni.isdigit()


### PR DESCRIPTION
The validator does not checks if the input NI is really a number.
That's now fixed.